### PR TITLE
Bump pystache to 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pydantic==1.8.2
 pyparsing==2.4.7
-pystache==0.5.4
+pystache==0.6.0
 python-multipart==0.0.5
 pytube==11.0.1
 PyYAML==6.0


### PR DESCRIPTION
For some reason, pystache < 0.5.x would not install with the rest of the requirements. Maybe because we don't use the same version of Python?